### PR TITLE
Add armv6 and armv7s archs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ IPHONEOS_ARM_OBJ_FILES := $(patsubst src/%.c,$(IPHONEOS_ARM_BUILD_DIR)/%.o,$(SRC
 IPHONEOS_ARM64_BUILD_DIR := build/iphoneos_arm64
 IPHONEOS_ARM64_OBJ_FILES := $(patsubst src/%.c,$(IPHONEOS_ARM64_BUILD_DIR)/%.o,$(SRC_FILES))
 
-CFLAGS = -I../../BaseBin/.include -Isrc -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch armv6 -arch armv7 -arch arm64 -arch arm64e -miphoneos-version-min=7.0 -fobjc-arc -O2
+CFLAGS = -I../../BaseBin/.include -Isrc -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch armv6 -arch armv7 -arch armv7s -arch arm64 -arch arm64e -miphoneos-version-min=7.0 -fobjc-arc -O2
 LDFLAGS =
 
 all: libroot_dyn_iphoneos-arm.a libroot_dyn_iphoneos-arm64.a

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ IPHONEOS_ARM_OBJ_FILES := $(patsubst src/%.c,$(IPHONEOS_ARM_BUILD_DIR)/%.o,$(SRC
 IPHONEOS_ARM64_BUILD_DIR := build/iphoneos_arm64
 IPHONEOS_ARM64_OBJ_FILES := $(patsubst src/%.c,$(IPHONEOS_ARM64_BUILD_DIR)/%.o,$(SRC_FILES))
 
-CFLAGS = -I../../BaseBin/.include -Isrc -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch armv7 -arch arm64 -arch arm64e -miphoneos-version-min=7.0 -fobjc-arc -O2
+CFLAGS = -I../../BaseBin/.include -Isrc -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch armv6 -arch armv7 -arch arm64 -arch arm64e -miphoneos-version-min=7.0 -fobjc-arc -O2
 LDFLAGS =
 
 all: libroot_dyn_iphoneos-arm.a libroot_dyn_iphoneos-arm64.a


### PR DESCRIPTION
Add the remaining architectures that Theos may default to when compiling for iphone; 
per https://github.com/theos/theos/blob/6b77f2247c6817bf40aa8229ce141cc695af7c3d/makefiles/targets/_common/iphone.mk