### PR TITLE
Add macro variants that support both C string and NSString

### DIFF
--- a/src/libroot.h
+++ b/src/libroot.h
@@ -1,10 +1,14 @@
 #include <sys/syslimits.h>
 
+__BEGIN_DECLS
+
 const char *_Nonnull libroot_dyn_get_root_prefix(void);
 const char *_Nonnull libroot_dyn_get_jbroot_prefix(void);
 const char *_Nonnull libroot_dyn_get_boot_uuid(void);
 char *_Nullable libroot_dyn_rootfspath(const char *_Nullable path, char *_Nullable resolvedPath);
 char *_Nullable libroot_dyn_jbrootpath(const char *_Nullable path, char *_Nullable resolvedPath);
+
+__END_DECLS
 
 #ifdef __OBJC__
 

--- a/src/libroot.h
+++ b/src/libroot.h
@@ -21,7 +21,7 @@ __END_DECLS
 #if __has_attribute(overloadable)
 // the C version needs to be inlined because we cannot re-use the static buffer
 __attribute__((__overloadable__, __always_inline__))
-static inline const char *__libroot_convert_path(char *(*converter)(const char *, char *), const char *path) {
+static inline const char *_Nullable __libroot_convert_path(char *_Nullable (*_Nonnull converter)(const char *_Nonnull, char *_Nullable), const char *_Nullable path) {
 	return __CONVERT_PATH_CSTRING(converter, path);
 }
 #endif /* __has_attribute(overloadable) */
@@ -38,7 +38,7 @@ static inline const char *__libroot_convert_path(char *(*converter)(const char *
 
 #if __has_attribute(overloadable)
 __attribute__((__overloadable__))
-static inline NSString *const __libroot_convert_path(char *(*converter)(const char *, char *), NSString *path) {
+static inline NSString *_Nullable __libroot_convert_path(char *_Nullable (*_Nonnull converter)(const char *_Nonnull, char *_Nullable), NSString *_Nullable path) {
 	return __CONVERT_PATH_NSSTRING(converter, path);
 }
 #endif /* __has_attribute(overloadable) */

--- a/src/libroot.h
+++ b/src/libroot.h
@@ -30,7 +30,8 @@ static inline const char *_Nullable __libroot_convert_path(char *_Nullable (*_No
 
 #define __CONVERT_PATH_NSSTRING(converter, path) ({ \
 	char tmpBuf[PATH_MAX]; \
-	[NSString stringWithUTF8String:converter(path.fileSystemRepresentation, tmpBuf)]; \
+	const char *converted = converter(path.fileSystemRepresentation, tmpBuf); \
+	converted ? [NSString stringWithUTF8String:converted] : nil; \
 })
 
 #define JBROOT_PATH_NSSTRING(path) __CONVERT_PATH_NSSTRING(libroot_dyn_jbrootpath, path)

--- a/src/libroot.h
+++ b/src/libroot.h
@@ -10,7 +10,32 @@ char *_Nullable libroot_dyn_jbrootpath(const char *_Nullable path, char *_Nullab
 
 __END_DECLS
 
+#if __has_attribute(overloadable)
+// the C version needs to be inlined because we cannot re-use the static buffer
+__attribute__((__overloadable__, __always_inline__))
+static inline const char *__libroot_convert_path(char *(*converter)(const char *, char *), const char *path) {
+	static char outPath[PATH_MAX];
+	return converter(path, outPath);
+}
+#endif /* __has_attribute(overloadable) */
+
+#define __CONVERT_PATH_CSTRING(converter, path) ({ \
+	static char outPath[PATH_MAX]; \
+	converter(path, outPath); \
+})
+
+#define JBROOT_PATH_CSTRING(path) __CONVERT_PATH_CSTRING(libroot_dyn_jbrootpath, path)
+#define ROOTFS_PATH_CSTRING(path) __CONVERT_PATH_CSTRING(libroot_dyn_rootfspath, path)
+
 #ifdef __OBJC__
+
+#if __has_attribute(overloadable)
+__attribute__((__overloadable__))
+static inline NSString *const __libroot_convert_path(char *(*converter)(const char *, char *), NSString *path) {
+	char tmpBuf[PATH_MAX];
+	return [NSString stringWithUTF8String:converter(path.fileSystemRepresentation, tmpBuf)];
+}
+#endif /* __has_attribute(overloadable) */
 
 #define __CONVERT_PATH_NSSTRING(converter, path) ({ \
 	char tmpBuf[PATH_MAX]; \
@@ -22,12 +47,12 @@ __END_DECLS
 
 #endif /* __OBJC__ */
 
-#define __CONVERT_PATH_CSTRING(converter, path) ({ \
-	static char outPath[PATH_MAX]; \
-	converter(path, outPath); \
-})
-
-#define JBROOT_PATH_CSTRING(path) __CONVERT_PATH_CSTRING(libroot_dyn_jbrootpath, path)
-#define ROOTFS_PATH_CSTRING(path) __CONVERT_PATH_CSTRING(libroot_dyn_rootfspath, path)
+#if __has_attribute(overloadable)
+#	define JBROOT_PATH(path) __libroot_convert_path(libroot_dyn_jbrootpath, path)
+#	define ROOTFS_PATH(path) __libroot_convert_path(libroot_dyn_rootfspath, path)
+#else
+#	define JBROOT_PATH(path) _Pragma("GCC error \"JBROOT_PATH is not supported with this compiler, use JBROOT_PATH_CSTRING or JBROOT_PATH_NSSTRING\"") path
+#	define ROOTFS_PATH(path) _Pragma("GCC error \"ROOTFS_PATH is not supported with this compiler, use ROOTFS_PATH_CSTRING or ROOTFS_PATH_NSSTRING\"") path
+#endif /* __has_attribute(overloadable) */
 
 #define JBRAND libroot_dyn_get_boot_uuid()

--- a/src/libroot.h
+++ b/src/libroot.h
@@ -10,15 +10,6 @@ char *_Nullable libroot_dyn_jbrootpath(const char *_Nullable path, char *_Nullab
 
 __END_DECLS
 
-#if __has_attribute(overloadable)
-// the C version needs to be inlined because we cannot re-use the static buffer
-__attribute__((__overloadable__, __always_inline__))
-static inline const char *__libroot_convert_path(char *(*converter)(const char *, char *), const char *path) {
-	static char outPath[PATH_MAX];
-	return converter(path, outPath);
-}
-#endif /* __has_attribute(overloadable) */
-
 #define __CONVERT_PATH_CSTRING(converter, path) ({ \
 	static char outPath[PATH_MAX]; \
 	converter(path, outPath); \
@@ -27,15 +18,15 @@ static inline const char *__libroot_convert_path(char *(*converter)(const char *
 #define JBROOT_PATH_CSTRING(path) __CONVERT_PATH_CSTRING(libroot_dyn_jbrootpath, path)
 #define ROOTFS_PATH_CSTRING(path) __CONVERT_PATH_CSTRING(libroot_dyn_rootfspath, path)
 
-#ifdef __OBJC__
-
 #if __has_attribute(overloadable)
-__attribute__((__overloadable__))
-static inline NSString *const __libroot_convert_path(char *(*converter)(const char *, char *), NSString *path) {
-	char tmpBuf[PATH_MAX];
-	return [NSString stringWithUTF8String:converter(path.fileSystemRepresentation, tmpBuf)];
+// the C version needs to be inlined because we cannot re-use the static buffer
+__attribute__((__overloadable__, __always_inline__))
+static inline const char *__libroot_convert_path(char *(*converter)(const char *, char *), const char *path) {
+	return __CONVERT_PATH_CSTRING(converter, path);
 }
 #endif /* __has_attribute(overloadable) */
+
+#ifdef __OBJC__
 
 #define __CONVERT_PATH_NSSTRING(converter, path) ({ \
 	char tmpBuf[PATH_MAX]; \
@@ -44,6 +35,13 @@ static inline NSString *const __libroot_convert_path(char *(*converter)(const ch
 
 #define JBROOT_PATH_NSSTRING(path) __CONVERT_PATH_NSSTRING(libroot_dyn_jbrootpath, path)
 #define ROOTFS_PATH_NSSTRING(path) __CONVERT_PATH_NSSTRING(libroot_dyn_rootfspath, path)
+
+#if __has_attribute(overloadable)
+__attribute__((__overloadable__))
+static inline NSString *const __libroot_convert_path(char *(*converter)(const char *, char *), NSString *path) {
+	return __CONVERT_PATH_NSSTRING(converter, path);
+}
+#endif /* __has_attribute(overloadable) */
 
 #endif /* __OBJC__ */
 


### PR DESCRIPTION
- Add `__BEGIN_DECLS` and `__END_DECLS` around C functions to improve importing into C++ 
- Adjust `__CONVERT_PATH_NSSTRING` to support `NULL` path
- Add `JBROOT_PATH` and `ROOTFS_PATH` macros that support taking either a `const char *` or `NSString *`
  - Only available when underlying feature is available in the compiler
    - Introduced to clang in 3.3
      - https://releases.llvm.org/3.3/tools/clang/docs/LanguageExtensions.html#function-overloading-in-c

---

(Intended for a squash merge)