### PR TITLE
Reduce symbol visibility

### DIFF
--- a/src/dyn.c
+++ b/src/dyn.c
@@ -15,24 +15,24 @@ static char *(*dyn_rootfspath)(const char *path, char *resolvedPath) = NULL;
 
 #ifdef IPHONEOS_ARM64
 
-const char *libroot_get_root_prefix_fallback(void)
+static const char *libroot_get_root_prefix_fallback(void)
 {
 	return "";
 }
 
-const char *libroot_get_jbroot_prefix_fallback(void)
+static const char *libroot_get_jbroot_prefix_fallback(void)
 {
 	return "/var/jb";
 }
 
 #else
 
-const char *libroot_get_root_prefix_fallback(void)
+static const char *libroot_get_root_prefix_fallback(void)
 {
 	return "";
 }
 
-const char *libroot_get_jbroot_prefix_fallback(void)
+static const char *libroot_get_jbroot_prefix_fallback(void)
 {
 	if (access("/var/LIY", F_OK) == 0) {
 		// Legacy support for XinaA15 1.x (For those two people still using it)
@@ -47,12 +47,12 @@ const char *libroot_get_jbroot_prefix_fallback(void)
 
 #endif
 
-const char *libroot_get_boot_uuid_fallback(void)
+static const char *libroot_get_boot_uuid_fallback(void)
 {
 	return "00000000-0000-0000-0000-000000000000";
 }
 
-char *libroot_rootfspath_fallback(const char *path, char *resolvedPath)
+static char *libroot_rootfspath_fallback(const char *path, char *resolvedPath)
 {
 	if (!path) return NULL;
 	if (!resolvedPath) resolvedPath = malloc(PATH_MAX);
@@ -81,7 +81,7 @@ char *libroot_rootfspath_fallback(const char *path, char *resolvedPath)
 	return resolvedPath;
 }
 
-char *libroot_jbrootpath_fallback(const char *path, char *resolvedPath)
+static char *libroot_jbrootpath_fallback(const char *path, char *resolvedPath)
 {
 	if (!path) return NULL;
 	if (!resolvedPath) resolvedPath = malloc(PATH_MAX);
@@ -110,7 +110,7 @@ char *libroot_jbrootpath_fallback(const char *path, char *resolvedPath)
 	return resolvedPath;
 }
 
-void libroot_load(void)
+static void libroot_load(void)
 {
 	static dispatch_once_t onceToken;
 	dispatch_once (&onceToken, ^{

--- a/src/libroot.h
+++ b/src/libroot.h
@@ -2,11 +2,15 @@
 
 __BEGIN_DECLS
 
+_Pragma("GCC visibility push(hidden)")
+
 const char *_Nonnull libroot_dyn_get_root_prefix(void);
 const char *_Nonnull libroot_dyn_get_jbroot_prefix(void);
 const char *_Nonnull libroot_dyn_get_boot_uuid(void);
 char *_Nullable libroot_dyn_rootfspath(const char *_Nullable path, char *_Nullable resolvedPath);
 char *_Nullable libroot_dyn_jbrootpath(const char *_Nullable path, char *_Nullable resolvedPath);
+
+_Pragma("GCC visibility pop")
 
 __END_DECLS
 


### PR DESCRIPTION
The libroot library is
1. statically linked
2. linked against by every project

For these reasons, the symbols from `libroot` should not be exported because
1. every dynamic library that links against with `libroot` will export `libroot` symbols
2. no target can benefit from using libroot symbols in another dynamic library because the current target will link against libroot anyway

---

Base branch:

```yml
--- !tapi-tbd
tbd-version:     4
targets:         [ arm64-ios, arm64e-ios ]
install-name:    '/usr/local/lib/libsam.dylib'
current-version: 0
compatibility-version: 0
exports:
  - targets:         [ arm64-ios, arm64e-ios ]
    symbols:         [ _libroot_dyn_get_boot_uuid, _libroot_dyn_get_jbroot_prefix, 
                       _libroot_dyn_get_root_prefix, _libroot_dyn_jbrootpath, _libroot_dyn_rootfspath, 
                       _libroot_get_boot_uuid_fallback, _libroot_get_jbroot_prefix_fallback, 
                       _libroot_get_root_prefix_fallback, _libroot_jbrootpath_fallback, 
                       _libroot_load, _libroot_rootfspath_fallback, _sample_symbol ]
...
```

With PR:

```yml
--- !tapi-tbd
tbd-version:     4
targets:         [ arm64-ios, arm64e-ios ]
install-name:    '/usr/local/lib/libsam.dylib'
current-version: 0
compatibility-version: 0
exports:
  - targets:         [ arm64-ios, arm64e-ios ]
    symbols:         [ _sample_symbol ]
...
```